### PR TITLE
Remove SPDX license expression warning and repository field warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/sapjax/TimoFM"
-    }
+    },
+    "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
         "electron-builder": "git://github.com/loopline-systems/electron-builder.git",
         "electron-packager": "git://github.com/maxogden/electron-packager.git",
         "electron-prebuilt": "git://github.com/mafintosh/electron-prebuilt.git"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/sapjax/TimoFM"
     }
 }


### PR DESCRIPTION
This is the part of the warnings that this commit will fix.

<img width="509" alt="screen shot 2015-10-30 at 6 32 55 pm" src="https://cloud.githubusercontent.com/assets/9198315/10860345/abfc0eae-7f34-11e5-8fda-14f59b1153ab.png">

MIT SPDX: https://spdx.org/licenses/MIT
